### PR TITLE
GB→GiB

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ valid characters: [0-9]
  ```100```
 
 ### trafficacct
-States if this is an unmetered or metered offering. In case of metered bandwidth the monthly included outbound (TX) traffic in GB ([GibiByte](https://en.wikipedia.org/wiki/Gibibyte)) MUST be provided. If no bandwidth is included, this value MUST be set to 0. If the hoster meters in+outbound the hoster provided value must be divided by two. This is an integer value.
+States if this is an unmetered or metered offering. In case of metered bandwidth the monthly included outbound (TX) traffic in GiB ([GibiByte](https://en.wikipedia.org/wiki/Gibibyte)) MUST be provided. If no bandwidth is included, this value MUST be set to 0. If the hoster meters in+outbound the hoster provided value must be divided by two. This is an integer value.
 
 On a server with multiple tor instances the total available monthly traffic of the server **MUST** be divided by the number of tor relay instances running on it.
 


### PR DESCRIPTION
The abbreviation for Gibibytes is GiB, not GB. GB is for Gigabytes. That makes it extra confusing. Have a look at the table in the top left of the Wikipedia article you link to.